### PR TITLE
[Chore] Discord log back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ out/
 **/resources/application.yml
 **/resources/database/
 **/resources/oauth2/
+**/resources/logback.xml
 Dockerfile
 docker-compose.yaml
 deploy_*.sh

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ sourceCompatibility = '17'
 
 repositories {
 	mavenCentral()
+
+	// discord log back
+	maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -33,10 +36,12 @@ dependencies {
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	implementation 'org.mariadb.jdbc:mariadb-java-client:2.6.2'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// discord log back
+	implementation 'com.github.napstr:logback-discord-appender:1.0.0'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
Discord와 연동해 서버 오류가 발생하면 바로 discord에서 확인할 수 있는 기능을 추가했습니다.

## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
FE, BE / BE끼리 소통을 위해 server error log를 공유할 수 있도록 Discord에 연결했습니다.
Spring boot에서 Error 레벨의 log가 발생하면 Discord로 전송할 수 있도록 구현했습니다.
Discord 정보 채널 -> back-error-log 채널에 전송할 수 있도록 Web hooking 했습니다.
Web hook url은 github repository secret variable로 등록했습니다.

변경 코드는 gitignore 파일이 대부분이라 노션에 업데이트 했으니 꼭 적용 부탁드립니다.

## 📋 추후 진행 상황


## 📌 리뷰 포인트


## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [ ] 유지-보수를 위해 주석 처리를 잘 작성했습니다
