### PR TITLE
[Feat] 닉네임 변경 최대 1회로 설정

### DIFF
--- a/src/main/java/com/ttubeog/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ttubeog/domain/auth/service/AuthService.java
@@ -58,6 +58,7 @@ public class AuthService {
                     .memberNumber(String.valueOf(memberInfo.getId()))
                     .platform(Platform.KAKAO)
                     .status(Status.ACTIVE)
+                    .nicknameChange(false)
                     .build();
 
             memberRepository.save(member);
@@ -100,7 +101,7 @@ public class AuthService {
                     return new OAuthTokenResponse(accessToken, refreshToken, true);
                 })
                 .orElseGet(() -> {
-                    Member newMember = new Member(email, platform, Status.ACTIVE, platformId);
+                    Member newMember = new Member(email, platform, Status.ACTIVE, platformId, false);
                     Member savedMember = memberRepository.save(newMember);
                     String accessToken = issueAccessToken(savedMember);
                     String refreshToken = issueRefreshToken();
@@ -118,9 +119,21 @@ public class AuthService {
         return Token.createRefreshToken();
     }
 
-    private void validateStatus(final Member findMember) {
-        if (findMember.getStatus() != Status.ACTIVE) {
-            throw new InvalidMemberException();
+    private void validateStatus(final Member member) {
+
+        // 멤버가 탈퇴해서 INACTIVE 된 경우
+        if (member.getStatus() != Status.ACTIVE) {
+            Member.builder()
+                    .id(member.getId())
+                    .oAuthId(member.getOAuthId())
+                    .nickname(member.getNickname())
+                    .memberNumber(member.getMemberNumber())
+                    .email(member.getEmail())
+                    .platformId(member.getPlatformId())
+                    .platform(member.getPlatform())
+                    .status(Status.ACTIVE)  // 상태를 비활성화로 설정
+                    .refreshToken(member.getRefreshToken())
+                    .build();
         }
     }
 

--- a/src/main/java/com/ttubeog/domain/member/application/MemberService.java
+++ b/src/main/java/com/ttubeog/domain/member/application/MemberService.java
@@ -77,15 +77,17 @@ public class MemberService {
         // 닉네임 업데이트
         memberRepository.updateMemberNickname(produceNicknameRequest.getNickname(), memberId);
 
-        Optional<Member> checkMember = memberRepository.findById(memberId);
+        // 닉네임 1회 변경 true로 변경
+        memberRepository.updateMemberNicknameChange(true, memberId);
 
+        Optional<Member> checkMember = memberRepository.findById(memberId);
         Member member = checkMember.get();
 
         MemberDetailRes memberDetailRes = MemberDetailRes.builder()
                 .id(member.getId())
                 .name(member.getNickname())
                 .platform(member.getPlatform())
-                .isUsed(true)
+                .isChanged(member.getNicknameChange())
                 .build();
 
         ApiResponse apiResponse = ApiResponse.builder()

--- a/src/main/java/com/ttubeog/domain/member/application/MemberService.java
+++ b/src/main/java/com/ttubeog/domain/member/application/MemberService.java
@@ -10,6 +10,7 @@ import com.ttubeog.domain.member.domain.Member;
 import com.ttubeog.domain.member.domain.repository.MemberRepository;
 import com.ttubeog.domain.member.dto.request.ProduceNicknameRequest;
 import com.ttubeog.domain.member.dto.response.MemberDetailRes;
+import com.ttubeog.domain.member.dto.response.MemberNicknameRes;
 import com.ttubeog.domain.member.exception.AlreadyChangeNicknameException;
 import com.ttubeog.domain.member.exception.FailureMemberDeleteException;
 import com.ttubeog.domain.member.exception.InvalidAccessTokenExpiredException;
@@ -70,7 +71,20 @@ public class MemberService {
         if (checkMemberIsChanged.isPresent()) {
             Member member = checkMemberIsChanged.get();
             if (member.isNickNameChanged()) {
-                throw new AlreadyChangeNicknameException();
+                Member checkMember = memberRepository.findById(memberId).get();
+
+                MemberNicknameRes memberNicknameRes = MemberNicknameRes.builder()
+                        .id(checkMember.getId())
+                        .nickname(checkMember.getNickname())
+                        .isChanged(checkMember.getNicknameChange())
+                        .build();
+
+                ApiResponse apiResponse = ApiResponse.builder()
+                        .check(false)
+                        .information(memberNicknameRes)
+                        .build();
+
+                return ResponseEntity.ok(apiResponse);
             }
         }
 
@@ -83,16 +97,15 @@ public class MemberService {
         Optional<Member> checkMember = memberRepository.findById(memberId);
         Member member = checkMember.get();
 
-        MemberDetailRes memberDetailRes = MemberDetailRes.builder()
+        MemberNicknameRes memberNicknameRes = MemberNicknameRes.builder()
                 .id(member.getId())
-                .name(member.getNickname())
-                .platform(member.getPlatform())
+                .nickname(produceNicknameRequest.getNickname())
                 .isChanged(member.getNicknameChange())
                 .build();
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
-                .information(memberDetailRes)
+                .information(memberNicknameRes)
                 .build();
 
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/com/ttubeog/domain/member/application/MemberService.java
+++ b/src/main/java/com/ttubeog/domain/member/application/MemberService.java
@@ -65,25 +65,6 @@ public class MemberService {
     public ResponseEntity<?> postMemberNickname(HttpServletRequest request, ProduceNicknameRequest produceNicknameRequest) {
         Long memberId = jwtTokenProvider.getMemberId(request);
 
-        if (memberRepository.existsByNickname(produceNicknameRequest.getNickname())) {
-            Optional<Member> checkMember = memberRepository.findById(memberId);
-            Member member = checkMember.get();
-
-            MemberDetailRes memberDetailRes = MemberDetailRes.builder()
-                    .id(member.getId())
-                    .name(member.getNickname())
-                    .platform(member.getPlatform())
-                    .isUsed(false)
-                    .build();
-
-            ApiResponse apiResponse = ApiResponse.builder()
-                    .check(true)
-                    .information(memberDetailRes)
-                    .build();
-
-            return ResponseEntity.ok(apiResponse);
-        }
-
         // 닉네임 1회 변경 여부 확인
         Optional<Member> checkMemberIsChanged = memberRepository.findById(memberId);
         if (checkMemberIsChanged.isPresent()) {
@@ -112,6 +93,20 @@ public class MemberService {
                 .information(memberDetailRes)
                 .build();
 
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @Transactional
+    // 닉네임 중복 확인
+    public ResponseEntity<?> postMemberNicknameCheck(HttpServletRequest request, ProduceNicknameRequest produceNicknameRequest) {
+        Long memberId = jwtTokenProvider.getMemberId(request);
+
+        Boolean isNicknameUsed = memberRepository.existsByNickname(produceNicknameRequest.getNickname());
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(!isNicknameUsed)
+                .information("닉네임 중복이면 check -> false, 중복이 아니면 check -> true")
+                .build();
         return ResponseEntity.ok(apiResponse);
     }
 

--- a/src/main/java/com/ttubeog/domain/member/domain/Member.java
+++ b/src/main/java/com/ttubeog/domain/member/domain/Member.java
@@ -64,6 +64,7 @@ public class Member extends BaseEntity {
     public boolean isRegisteredOAuthMember() {
         return nickname != null;
     }
+    public boolean isNickNameChanged() { return nicknameChange; }
 
     public void updateName(String name) {
         this.nickname = name;

--- a/src/main/java/com/ttubeog/domain/member/domain/Member.java
+++ b/src/main/java/com/ttubeog/domain/member/domain/Member.java
@@ -45,6 +45,9 @@ public class Member extends BaseEntity {
     @Column(name = "refresh_token")
     private String refreshToken;
 
+    @Column(name = "nickname_changed")
+    private boolean nicknameChange;
+
 
     public Member(String email, Platform platform, Status status, String memberNumber) {
         this.email = email;

--- a/src/main/java/com/ttubeog/domain/member/domain/Member.java
+++ b/src/main/java/com/ttubeog/domain/member/domain/Member.java
@@ -46,15 +46,16 @@ public class Member extends BaseEntity {
     private String refreshToken;
 
     @Column(name = "nickname_changed")
-    private boolean nicknameChange;
+    private Boolean nicknameChange;
 
 
-    public Member(String email, Platform platform, Status status, String memberNumber) {
+    public Member(String email, Platform platform, Status status, String memberNumber, Boolean nicknameChange) {
         this.email = email;
         this.platform = platform;
         this.platformId = platformId;
         this.status = status;
         this.memberNumber = memberNumber;
+        this.nicknameChange = nicknameChange;
     }
 
     public Member(Status status) {

--- a/src/main/java/com/ttubeog/domain/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/ttubeog/domain/member/domain/repository/MemberRepository.java
@@ -37,6 +37,11 @@ public interface MemberRepository extends JpaRepository<Member,Long>{
     @Query("update Member as m set m.nickname = :nickName where m.id = :memberId")
     void updateMemberNickname(@Param("nickName") String nickName, @Param("memberId") Long memberId);
 
+    @Modifying
+    @Query("update Member as m set m.nicknameChange = :nicknameChange where m.id = :memberId")
+    void updateMemberNicknameChange(@Param("nicknameChange") Boolean nicknameChange, @Param("memberId") Long memberId);
+
+
     Boolean existsByNickname(String nickname);
 
 }

--- a/src/main/java/com/ttubeog/domain/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/ttubeog/domain/member/domain/repository/MemberRepository.java
@@ -3,7 +3,6 @@ package com.ttubeog.domain.member.domain.repository;
 import com.ttubeog.domain.auth.domain.Platform;
 import com.ttubeog.domain.auth.domain.Status;
 import com.ttubeog.domain.member.domain.Member;
-import com.ttubeog.domain.member.dto.request.ProduceNicknameRequest;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -36,7 +35,7 @@ public interface MemberRepository extends JpaRepository<Member,Long>{
 
     @Modifying
     @Query("update Member as m set m.nickname = :nickName where m.id = :memberId")
-    void updateUserNickname(@Param("nickName") String nickName, @Param("memberId") Long memberId);
+    void updateMemberNickname(@Param("nickName") String nickName, @Param("memberId") Long memberId);
 
     Boolean existsByNickname(String nickname);
 

--- a/src/main/java/com/ttubeog/domain/member/dto/response/MemberDetailRes.java
+++ b/src/main/java/com/ttubeog/domain/member/dto/response/MemberDetailRes.java
@@ -21,6 +21,8 @@ public class MemberDetailRes {
 
     private Boolean isUsed;
 
+    private Boolean isChanged;
+
     public static MemberDetailRes toDto(Member member) {
         return MemberDetailRes.builder()
                 .id(member.getId())

--- a/src/main/java/com/ttubeog/domain/member/dto/response/MemberDetailRes.java
+++ b/src/main/java/com/ttubeog/domain/member/dto/response/MemberDetailRes.java
@@ -19,8 +19,6 @@ public class MemberDetailRes {
 
     private Platform platform;
 
-    private Boolean isUsed;
-
     private Boolean isChanged;
 
     public static MemberDetailRes toDto(Member member) {

--- a/src/main/java/com/ttubeog/domain/member/dto/response/MemberNicknameRes.java
+++ b/src/main/java/com/ttubeog/domain/member/dto/response/MemberNicknameRes.java
@@ -1,0 +1,29 @@
+package com.ttubeog.domain.member.dto.response;
+
+import com.ttubeog.domain.auth.domain.Platform;
+import com.ttubeog.domain.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberNicknameRes {
+
+    private Long id;
+    private String nickname;
+
+    private Boolean isChanged;
+
+    public static MemberNicknameRes toDto(Member member) {
+        return MemberNicknameRes.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .isChanged(member.getNicknameChange())
+                .build();
+    }
+
+}

--- a/src/main/java/com/ttubeog/domain/member/exception/AlreadyChangeNicknameException.java
+++ b/src/main/java/com/ttubeog/domain/member/exception/AlreadyChangeNicknameException.java
@@ -1,0 +1,9 @@
+package com.ttubeog.domain.member.exception;
+
+
+public class AlreadyChangeNicknameException extends RuntimeException {
+
+    public AlreadyChangeNicknameException(){
+        super("이미 닉네임을 변경한 회원입니다.");
+    }
+}

--- a/src/main/java/com/ttubeog/domain/member/presentation/MemberController.java
+++ b/src/main/java/com/ttubeog/domain/member/presentation/MemberController.java
@@ -4,6 +4,7 @@ import com.ttubeog.domain.auth.dto.response.OAuthTokenResponse;
 import com.ttubeog.domain.member.application.MemberService;
 import com.ttubeog.domain.member.dto.request.ProduceNicknameRequest;
 import com.ttubeog.domain.member.dto.response.MemberDetailRes;
+import com.ttubeog.domain.member.dto.response.MemberNicknameRes;
 import com.ttubeog.global.payload.ErrorResponse;
 import com.ttubeog.global.payload.Message;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,9 +44,9 @@ public class MemberController {
         return memberService.getCurrentUser(request);
     }
 
-    @Operation(summary = "닉네임 설정", description = "현재 접속된 멤버의 초기 닉네임을 설정합니다.")
+    @Operation(summary = "닉네임 설정", description = "현재 접속된 멤버의 초기 닉네임을 설정합니다.닉네임을 이미 변경한 유저는 isChanged == true로 반환되며, 닉네임이 업데이트 되지 않습니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "닉네임 설정", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MemberDetailRes.class))}),
+            @ApiResponse(responseCode = "200", description = "닉네임 설정", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MemberNicknameRes.class))}),
             @ApiResponse(responseCode = "400", description = "닉네임 설정 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
     @PostMapping(value = "/nickname")

--- a/src/main/java/com/ttubeog/domain/member/presentation/MemberController.java
+++ b/src/main/java/com/ttubeog/domain/member/presentation/MemberController.java
@@ -57,7 +57,7 @@ public class MemberController {
 
     @Operation(summary = "닉네임 중복 확인", description = "닉네임의 중복을 확인합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "닉네임 설정 가능", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MemberDetailRes.class))}),
+            @ApiResponse(responseCode = "200", description = "닉네임 설정 가능", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = com.ttubeog.global.payload.ApiResponse.class))}),
             @ApiResponse(responseCode = "400", description = "닉네임 설정 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
     @PostMapping(value = "/nickname/check")
@@ -66,6 +66,7 @@ public class MemberController {
     ) {
         return memberService.postMemberNicknameCheck(request, produceNicknameRequest);
     }
+
 
     @Operation(summary = "토큰 재발급", description = "현재 접속된 멤버의 토큰을 재발급 합니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/ttubeog/domain/member/presentation/MemberController.java
+++ b/src/main/java/com/ttubeog/domain/member/presentation/MemberController.java
@@ -55,6 +55,18 @@ public class MemberController {
         return memberService.postMemberNickname(request, produceNicknameRequest);
     }
 
+    @Operation(summary = "닉네임 중복 확인", description = "닉네임의 중복을 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임 설정 가능", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MemberDetailRes.class))}),
+            @ApiResponse(responseCode = "400", description = "닉네임 설정 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @PostMapping(value = "/nickname/check")
+    public ResponseEntity<?> checkNicknameAvailability(
+            HttpServletRequest request, @RequestBody ProduceNicknameRequest produceNicknameRequest
+    ) {
+        return memberService.postMemberNicknameCheck(request, produceNicknameRequest);
+    }
+
     @Operation(summary = "토큰 재발급", description = "현재 접속된 멤버의 토큰을 재발급 합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "토큰 재발급 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = OAuthTokenResponse.class))}),


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
1. 닉네임 중복 확인 로직과 닉네임 설정 로직을 분리했습니다.
2. 닉네임 변경 여부 필드를 Member 엔티티에 추가하여, 해당 값으로 닉네임 1회 변경 여부를 확인하도록 구현했습니다.
3. 닉네임 변경을 한 회원의 경우, 닉네임이 변경되지 않도록 구현했습니다.

## 📋 추후 진행 상황
회원 탈퇴 API 구체화


## 📌 리뷰 포인트
기존 닉네임 변경 로직에서 중복 확인을 분리하였으니 유의해서 리뷰 체크해주시면 될 것 같습니다!



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 유지-보수를 위해 주석 처리를 잘 작성했습니다
